### PR TITLE
Resolve against relative paths when generating URI

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -60,6 +60,8 @@ module.exports = function(file, options, callback) {
 	}
 
 	function getUri(options) {
+		options.host = options.host.replace(/\/?$/, '/');
+
 		var packageUri = url.resolve(options.host, 'api/packages/raw');
 		if (!!options.replace) {
 			packageUri += '?replace=true';

--- a/lib/push.js
+++ b/lib/push.js
@@ -60,7 +60,7 @@ module.exports = function(file, options, callback) {
 	}
 
 	function getUri(options) {
-		var packageUri = url.resolve(options.host, '/api/packages/raw');
+		var packageUri = url.resolve(options.host, 'api/packages/raw');
 		if (!!options.replace) {
 			packageUri += '?replace=true';
 		}

--- a/test.js
+++ b/test.js
@@ -31,30 +31,28 @@ describe('push', function() {
   });
 
   describe('build url', function () {
-    var req;
-
     it('should include `replace` parameter if it is provided', function () {
       octo.push(new Buffer('hello world'), { replace: true, host: 'http://myweb/' });
-      req = postStub.firstCall.args[0];
+      var req = postStub.firstCall.args[0];
       expect(req.url).to.equal('http://myweb/api/packages/raw?replace=true');
       postStub.reset();
     });
 
     it('should build correct url', function () {
       octo.push(new Buffer('hello world'), { host: 'http://myweb' });
-      req = postStub.firstCall.args[0];
+      var req = postStub.firstCall.args[0];
       expect(req.url).to.equal('http://myweb/api/packages/raw');
     });
 
     it('should build correct url with port', function () {
       octo.push(new Buffer('hello world'), { host: 'http://myweb:3000' });
-      req = postStub.firstCall.args[0];
+      var req = postStub.firstCall.args[0];
       expect(req.url).to.equal('http://myweb:3000/api/packages/raw');
     });
 
     it('should build correct url with relative path', function () {
       octo.push(new Buffer('hello world'), { host: 'http://myweb/path/to/octopus/' });
-      req = postStub.firstCall.args[0];
+      var req = postStub.firstCall.args[0];
       expect(req.url).to.equal('http://myweb/path/to/octopus/api/packages/raw');
     });
   });

--- a/test.js
+++ b/test.js
@@ -41,7 +41,7 @@ describe('push', function() {
     expect(req.url).to.equal('http://myweb/api/packages/raw');
   });
 
-  it('should return resoponse body if request successful', function(done) {
+  it('should return response body if request successful', function(done) {
     var body = { prop: 12 };
 
     octo.push(new Buffer('hello world'), {

--- a/test.js
+++ b/test.js
@@ -30,15 +30,33 @@ describe('push', function() {
     expect(req.formData.file.options.filename).to.equal('package.tar');
   });
 
-  it('builds correct url', function() {
-    octo.push(new Buffer('hello world'), { replace: true, host: 'http://myweb/' });
-    var req = postStub.firstCall.args[0];
-    expect(req.url).to.equal('http://myweb/api/packages/raw?replace=true');
-    postStub.reset();
+  describe('build url', function () {
+    var req;
 
-    octo.push(new Buffer('hello world'), { host: 'http://myweb' });
-    req = postStub.firstCall.args[0];
-    expect(req.url).to.equal('http://myweb/api/packages/raw');
+    it('should include `replace` parameter if it is provided', function () {
+      octo.push(new Buffer('hello world'), { replace: true, host: 'http://myweb/' });
+      req = postStub.firstCall.args[0];
+      expect(req.url).to.equal('http://myweb/api/packages/raw?replace=true');
+      postStub.reset();
+    });
+
+    it('should build correct url', function () {
+      octo.push(new Buffer('hello world'), { host: 'http://myweb' });
+      req = postStub.firstCall.args[0];
+      expect(req.url).to.equal('http://myweb/api/packages/raw');
+    });
+
+    it('should build correct url with port', function () {
+      octo.push(new Buffer('hello world'), { host: 'http://myweb:3000' });
+      req = postStub.firstCall.args[0];
+      expect(req.url).to.equal('http://myweb:3000/api/packages/raw');
+    });
+
+    it('should build correct url with relative', function () {
+      octo.push(new Buffer('hello world'), { host: 'http://myweb/path/to/octopus/' });
+      req = postStub.firstCall.args[0];
+      expect(req.url).to.equal('http://myweb/path/to/octopus/api/packages/raw');
+    });
   });
 
   it('should return response body if request successful', function(done) {

--- a/test.js
+++ b/test.js
@@ -52,7 +52,7 @@ describe('push', function() {
       expect(req.url).to.equal('http://myweb:3000/api/packages/raw');
     });
 
-    it('should build correct url with relative', function () {
+    it('should build correct url with relative path', function () {
       octo.push(new Buffer('hello world'), { host: 'http://myweb/path/to/octopus/' });
       req = postStub.firstCall.args[0];
       expect(req.url).to.equal('http://myweb/path/to/octopus/api/packages/raw');

--- a/test.js
+++ b/test.js
@@ -32,27 +32,64 @@ describe('push', function() {
 
   describe('build url', function () {
     it('should include `replace` parameter if it is provided', function () {
+      var req;
+
+      // it should work with a trailing slash
       octo.push(new Buffer('hello world'), { replace: true, host: 'http://myweb/' });
-      var req = postStub.firstCall.args[0];
+      req = postStub.firstCall.args[0];
       expect(req.url).to.equal('http://myweb/api/packages/raw?replace=true');
+
       postStub.reset();
+
+      // it should work without a trailing slash
+      octo.push(new Buffer('hello world'), { replace: true, host: 'http://myweb' });
+      req = postStub.firstCall.args[0];
+      expect(req.url).to.equal('http://myweb/api/packages/raw?replace=true');
     });
 
     it('should build correct url', function () {
+      var req;
+
+      // it should work with a trailing slash
       octo.push(new Buffer('hello world'), { host: 'http://myweb' });
-      var req = postStub.firstCall.args[0];
+      req = postStub.firstCall.args[0];
+      expect(req.url).to.equal('http://myweb/api/packages/raw');
+
+      // it should work without a trailing slash
+      octo.push(new Buffer('hello world'), { host: 'http://myweb/' });
+      req = postStub.firstCall.args[0];
       expect(req.url).to.equal('http://myweb/api/packages/raw');
     });
 
     it('should build correct url with port', function () {
+      var req;
+
+      // it should work with a trailing slash
+      octo.push(new Buffer('hello world'), { host: 'http://myweb:3000/' });
+      req = postStub.firstCall.args[0];
+      expect(req.url).to.equal('http://myweb:3000/api/packages/raw');
+
+      postStub.reset();
+
+      // it should work without a trailing slash
       octo.push(new Buffer('hello world'), { host: 'http://myweb:3000' });
-      var req = postStub.firstCall.args[0];
+      req = postStub.firstCall.args[0];
       expect(req.url).to.equal('http://myweb:3000/api/packages/raw');
     });
 
     it('should build correct url with relative path', function () {
+      var req;
+
+      // it should should work with a trailing slash
       octo.push(new Buffer('hello world'), { host: 'http://myweb/path/to/octopus/' });
-      var req = postStub.firstCall.args[0];
+      req = postStub.firstCall.args[0];
+      expect(req.url).to.equal('http://myweb/path/to/octopus/api/packages/raw');
+
+      postStub.reset();
+
+      // it should should work without a trailing slash
+      octo.push(new Buffer('hello world'), { host: 'http://myweb/path/to/octopus' });
+      req = postStub.firstCall.args[0];
       expect(req.url).to.equal('http://myweb/path/to/octopus/api/packages/raw');
     });
   });


### PR DESCRIPTION
This fixes an issue with `octo.post` where generating a URL for an Octopus instance running behind a relative path (e.g., `http://my-server/path/to/octopus`) would not include the path.
