### PR TITLE
Add deploy command to octo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Required. The project name.
 Required. The name of the environment to deploy to.
 
 #### options.releaseVersion
-Required. The version of the release to be deployed.
+The version of the release to be deployed, defaults to 'latest'.
 
 
 
@@ -117,7 +117,7 @@ octo.deploy({
         host: 'http://octopus-server/', 
         apikey: 'API-XXXXXXXXX',
         projectName: 'OctoPackJs',
-        releaseVersion: '1.2.4',
+        releaseVersion: '1.2.4', // or 'latest'
         deployTo: 'Stage'
     }, function(err, result) {
      if(!err) {

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Required. The URL of the Octopus Server instance the release should be deployed 
 #### options.projectName
 Required. The project name.
 
-#### options.deployTo
+#### options.environmentName
 Required. The name of the environment to deploy to.
 
 #### options.releaseVersion
@@ -118,7 +118,7 @@ octo.deploy({
         apikey: 'API-XXXXXXXXX',
         projectName: 'OctoPackJs',
         releaseVersion: '1.2.4', // or 'latest'
-        deployTo: 'Stage'
+        environmentName: 'Stage'
     }, function(err, result) {
      if(!err) {
         console.log("Project released:" + body.Title + " v"+ body.Version); 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ octo.deploy({
         environmentName: 'Stage'
     }, function(err, result) {
      if(!err) {
-        console.log("Project released:" + body.Title + " v"+ body.Version); 
+        console.log("Deployment created! TaskId: " + result.TaskId + " QueueTime: "+ result.QueueTime); 
      }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ octo.push('./bin/Sample.Web.3.2.1.tar.gz', {
 });
 ```
 
-#### Push
+#### Deploy
 ```js
 var octo = require('@octopusdeploy/octopackjs');
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ If a Stream or Buffer object is provided in the `file` parameter, the package na
 #### callback
 Invoked when the HTTP request has completed. The `data` object contains the HTTP response body that was returned as a result of a successful push.
 
+### octo.deploy(options, function callback(err, data))
+
+#### options.apiKey
+Key linked to account in `Project Deployer` role.
+
+#### options.host
+Required. The URL of the Octopus Server instance the release should be deployed on.
+
+#### options.projectName
+Required. The project name.
+
+#### options.deployTo
+Required. The name of the environment to deploy to.
+
+#### options.releaseVersion
+Required. The version of the release to be deployed.
+
+
+
 ## Usage Examples
 
 #### Pack
@@ -86,6 +105,23 @@ octo.push('./bin/Sample.Web.3.2.1.tar.gz', {
     }, function(err, result) {
      if(!err) {
         console.log("Package Pushed:" + body.Title + " v"+ body.Version +" (" + fileSizeString(body.PackageSizeBytes) +"nytes)"); 
+     }
+});
+```
+
+#### Push
+```js
+var octo = require('@octopusdeploy/octopackjs');
+
+octo.deploy({
+        host: 'http://octopus-server/', 
+        apikey: 'API-XXXXXXXXX',
+        projectName: 'OctoPackJs',
+        releaseVersion: '1.2.4',
+        deployTo: 'Stage'
+    }, function(err, result) {
+     if(!err) {
+        console.log("Project released:" + body.Title + " v"+ body.Version); 
      }
 });
 ```

--- a/index.js
+++ b/index.js
@@ -2,5 +2,6 @@
 
 module.exports = {
 	pack: require('./lib/pack.js'),
-	push: require('./lib/push.js')
+	push: require('./lib/push.js'),
+    deploy: require('./lib/deploy.js')
 };

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -50,7 +50,7 @@ function getEnvironment(environmentName, callback) {
 
 function getRelease(releaseVersion, project, callback) {
     var version = releaseVersion || 'latest';
-    if(verbose) { console.log('Getting release for version \'' + releaseVersion + '\''); }
+    if(verbose) { console.log('Getting release for version \'' + version + '\''); }
 
     var requestOptions = extend({url: url.resolve(octopusUrl, 'api/projects/' + project.Id + '/releases/') });
     request.get(requestOptions, handleResponse.bind(this, function(body){
@@ -66,8 +66,7 @@ function deploy(deployOptions, callback){
     var formData = JSON.stringify(deployOptions, null, 4);
     var requestOptions = extend({
         url: url.resolve(octopusUrl, 'api/deployments'),
-        form: formData,
-        json: false
+        form: formData
     });
     request.post(requestOptions, function(err, resp, body){
         if(err) {

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -17,11 +17,11 @@ module.exports = function(options, callback) {
     extend = Object.assign.bind(null, {}, { headers: apiHeader, json: true });
     
     getProject(options.projectName, function(project){
-       getEnvironment(options.deployTo, function(environment){
+       getEnvironment(options.environmentName, function(environment){
            getRelease(options.releaseVersion, project, function(release){
                 deploy({
-                    ReleaseId: release.Id,
-                    EnvironmentId: environment.Id
+                    ReleaseID: release.Id,
+                    EnvironmentID: environment.Id
                 }, callback);
             });
        });
@@ -51,10 +51,10 @@ function getEnvironment(environmentName, callback) {
 function getRelease(releaseVersion, project, callback) {
     var version = releaseVersion || 'latest';
     if(verbose) { console.log('Getting release for version \'' + releaseVersion + '\''); }
-    
+
     var requestOptions = extend({url: url.resolve(octopusUrl, 'api/projects/' + project.Id + '/releases/') });
     request.get(requestOptions, handleResponse.bind(this, function(body){
-        if(/latest/i.test(releaseVersion)) {
+        if(/latest/i.test(version)) {
             callback(body.Items[0]);    
         } else {
             callback(body.Items.filter(function(item){ return item.Version === releaseVersion; })[0]);

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -8,6 +8,8 @@ var octopusUrl;
 
 module.exports = function(options, callback) {
 	verbose = !!options.verbose;
+    nullCheck(options, 'host');
+    
     octopusUrl = options.host.replace(/\/?$/, '/');
     var apiHeader = { 'X-Octopus-ApiKey': options.apikey };
     
@@ -27,21 +29,21 @@ module.exports = function(options, callback) {
 };
 
 function getProject(projectName, callback) {
-    if(!projectName) { throw new Error('Option "projectName" is undefined'); }
+    nullCheck(projectName, 'projectName', true);
     if(verbose) { console.log('Getting project info for \'' + projectName + '\''); }
     
     var requestOptions = extend({url: url.resolve(octopusUrl, 'api/projects/' + projectName) });
     request.get(requestOptions, handleResponse.bind(this, callback));
 }
 
-function getEnvironment(deployTo, callback) {
-    if(!deployTo) { throw new Error('Option "deployTo" is undefined'); }
-    if(verbose) { console.log('Getting environement info for \'' + deployTo + '\''); }
+function getEnvironment(environmentName, callback) {
+    nullCheck(environmentName, 'environmentName', true);
+    if(verbose) { console.log('Getting environement info for \'' + environmentName + '\''); }
     
     var requestOptions = extend({url: url.resolve(octopusUrl, 'api/Environments/all/') });
     request.get(requestOptions, handleResponse.bind(this, function(body){
         callback(body.filter(function(env){
-            return env.Name === deployTo;
+            return env.Name === environmentName;
         })[0])
     }));
 }
@@ -90,4 +92,33 @@ function handleResponse(callback, err, resp, body){
         throw err;
     }
     callback(body);
+}
+
+function nullCheck(root, property, rootIsProperty) {
+    var prop = rootIsProperty ? root : root[property]; 
+    if(typeof prop === 'undefined') { throw new Error('Option "'+property+'" is undefined'); }
+}
+
+// Object.assign polyfill from MDN
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+if (typeof Object.assign != 'function') {
+  Object.assign = function(target) {
+    'use strict';
+    if (target == null) {
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+
+    target = Object(target);
+    for (var index = 1; index < arguments.length; index++) {
+      var source = arguments[index];
+      if (source != null) {
+        for (var key in source) {
+          if (Object.prototype.hasOwnProperty.call(source, key)) {
+            target[key] = source[key];
+          }
+        }
+      }
+    }
+    return target;
+  };
 }

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,0 +1,93 @@
+'use strict';
+
+var request = require('request');
+var url = require('url');
+var extend = null;
+var verbose = false;
+var octopusUrl;
+
+module.exports = function(options, callback) {
+	verbose = !!options.verbose;
+    octopusUrl = options.host.replace(/\/?$/, '/');
+    var apiHeader = { 'X-Octopus-ApiKey': options.apikey };
+    
+    // helper for request-options
+    extend = Object.assign.bind(null, {}, { headers: apiHeader, json: true });
+    
+    getProject(options.projectName, function(project){
+       getEnvironment(options.deployTo, function(environment){
+           getRelease(options.releaseVersion, project, function(release){
+                deploy({
+                    ReleaseId: release.Id,
+                    EnvironmentId: environment.Id
+                }, callback);
+            });
+       });
+    });
+};
+
+function getProject(projectName, callback) {
+    if(!projectName) { throw new Error('Option "projectName" is undefined'); }
+    if(verbose) { console.log('Getting project info for \'' + projectName + '\''); }
+    
+    var requestOptions = extend({url: url.resolve(octopusUrl, 'api/projects/' + projectName) });
+    request.get(requestOptions, handleResponse.bind(this, callback));
+}
+
+function getEnvironment(deployTo, callback) {
+    if(!deployTo) { throw new Error('Option "deployTo" is undefined'); }
+    if(verbose) { console.log('Getting environement info for \'' + deployTo + '\''); }
+    
+    var requestOptions = extend({url: url.resolve(octopusUrl, 'api/Environments/all/') });
+    request.get(requestOptions, handleResponse.bind(this, function(body){
+        callback(body.filter(function(env){
+            return env.Name === deployTo;
+        })[0])
+    }));
+}
+
+function getRelease(releaseVersion, project, callback) {
+    if(!releaseVersion) { throw new Error('option "releaseVersion" is undefined'); }
+    if(verbose) { console.log('Getting release with version \'' + releaseVersion + '\''); }
+    
+    var requestOptions = extend({url: url.resolve(octopusUrl, 'api/projects/' + project.Id + '/releases/') });
+    request.get(requestOptions, handleResponse.bind(this, function(body){
+        if(/latest/i.test(releaseVersion)) {
+            callback(body.Items[0]);    
+        } else {
+            callback(body.Items.filter(function(item){ return item.Version === releaseVersion; })[0]);
+        }
+    }));
+}
+
+function deploy(deployOptions, callback){
+    var formData = JSON.stringify(deployOptions, null, 4);
+    var requestOptions = extend({
+        url: url.resolve(octopusUrl, 'api/deployments'),
+        form: formData,
+        json: false
+    });
+    request.post(requestOptions, function(err, resp, body){
+        if(err) {
+            callback(err);
+            return;
+        }
+        if (resp.statusCode === 200 || resp.statusCode === 201) {
+            callback(null, body);
+        } else {
+            callback({
+                statusCode: resp.statusCode,
+                statusMessage: resp.statusMessage,
+                body: body,
+                response: resp
+            });
+        }
+    });
+}
+
+function handleResponse(callback, err, resp, body){
+    if(err) {
+        throw err;
+    }
+    callback(body);
+}

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -47,8 +47,8 @@ function getEnvironment(deployTo, callback) {
 }
 
 function getRelease(releaseVersion, project, callback) {
-    if(!releaseVersion) { throw new Error('option "releaseVersion" is undefined'); }
-    if(verbose) { console.log('Getting release with version \'' + releaseVersion + '\''); }
+    var version = releaseVersion || 'latest';
+    if(verbose) { console.log('Getting release for version \'' + releaseVersion + '\''); }
     
     var requestOptions = extend({url: url.resolve(octopusUrl, 'api/projects/' + project.Id + '/releases/') });
     request.get(requestOptions, handleResponse.bind(this, function(body){

--- a/test.js
+++ b/test.js
@@ -99,7 +99,7 @@ describe('pack', function() {
             expect(data.size).to.be.above(0);
             expect(data.name).not.to.be.null;
             console.log(data.path);
-            expect(data.path.indexOf('bin/')).to.not.equal(-1);
+            expect(/tar\.gz/.test(data.path)).to.be.true;
 
             fs.exists(data.path, function (exists) {
                 expect(exists).to.be.true;

--- a/test.js
+++ b/test.js
@@ -158,9 +158,74 @@ describe('deploy', function(){
         getStub.restore();
     });
     
+    it('is exposed on the root object', function(){
+        expect(octo.deploy).not.to.be.null;
+    });
+    
+    it('throws for non existing host', function(){
+        expect(function(){ octo.deploy({}); }).to
+        .throw('Option "host" is undefined');
+    });
+    
     it('throws for non existing projectName', function(){
         expect(function(){ octo.deploy({host:''}); }).to
         .throw('Option "projectName" is undefined');
+    });
+    
+    it('throws for non existing environmentName', function(){
+        octo.deploy({host:'', projectName: 'pname'});
+        var cb = getStub.getCall(0).args[1];
+        
+        expect(function(){
+            cb(null, [{Id:'projectId'}])
+        }).to.throw('Option "environmentName" is undefined');
+    });
+    
+    it('passes projectId to getRelease', function(){
+        // arrange
+        var allEnvs = [{ Name: 'test', Id: 'env1' }];
+        var expectedId = 'myPid';
+        
+        // act
+        octo.deploy({host:'', projectName: 'pname', environmentName: 'test'});
+        getStub.getCall(0).args[1](null, null, {Id: expectedId});
+        getStub.getCall(1).args[1](null, null, allEnvs);
+        
+        // assert
+        expect(getStub.getCall(2).args[0].url).to.contain(expectedId);
+    });
+    
+    it('uses first release in list if releaseVersion undefined', function(){
+        // arrange
+        var allEnvs = [{ Name: 'test', Id: 'env1' }];
+        var allReleases = { Items: [ {Version: '0.0.1', Id: '0'}, {Version: '0.0.5', Id: '1'} ] }
+        
+        // act
+        octo.deploy({host:'', projectName: 'pname', environmentName: 'test'});
+        getStub.getCall(0).args[1](null, null, {Id: 'id'});
+        getStub.getCall(1).args[1](null, null, allEnvs);
+        getStub.getCall(2).args[1](null, null, allReleases);
+        
+        // assert
+        var deployData = JSON.parse(postStub.getCall(0).args[0].form);
+        expect(deployData.EnvironmentID).to.equal(allEnvs[0].Id);
+    });
+    
+    it('passes release and environment to deploy', function(){
+        // arrange
+        var allEnvs = [{ Name: 'test', Id: 'env1' }];
+        var allReleases = { Items: [ {Version: '9.9.9', Id: 'version9'} ] }
+        
+        // act
+        octo.deploy({host:'', projectName: 'pname', environmentName: 'test', releaseVersion: '9.9.9'});
+        getStub.getCall(0).args[1](null, null, {Id: 'id'});
+        getStub.getCall(1).args[1](null, null, allEnvs);
+        getStub.getCall(2).args[1](null, null, allReleases);
+        
+        // assert
+        var deployData = JSON.parse(postStub.getCall(0).args[0].form);
+        expect(deployData.EnvironmentID).to.equal(allEnvs[0].Id);
+        expect(deployData.ReleaseID).to.equal(allReleases.Items[0].Id);
     });
     
 })

--- a/test.js
+++ b/test.js
@@ -143,3 +143,24 @@ describe('pack', function() {
         });
   });
 });
+
+describe('deploy', function(){
+    
+    var postStub, getStub;
+
+    beforeEach(function(){
+        postStub = sinon.stub(request, 'post');
+        getStub = sinon.stub(request, 'get');
+    });
+
+    afterEach(function(){
+        postStub.restore();
+        getStub.restore();
+    });
+    
+    it('throws for non existing projectName', function(){
+        expect(function(){ octo.deploy({host:''}); }).to
+        .throw('Option "projectName" is undefined');
+    });
+    
+})


### PR DESCRIPTION
### Description

Thought it would be great to have a `deploy` command as part of this nifty little tool, I know I'd really need it for javascript projects where I dont want to set up auto deploying phases in Octopus.

I stole the concept/workflow from your [powershell examples](https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/REST/PowerShell/Deployments/CreateReleaseAndDeployment.ps1)

I intended to make the interface as much like the other commands as I could but I'm sure there's alot of room for improvement.

``` js
octo.deploy({
    host: 'http://octopus-server',
    apikey: 'API-XXXXX',
    projectName: 'octopackjs',
    environmentName: 'Stage',
    releaseVersion: '0.5.0'
})
```

It would be great to get your thoughts and feedback!

**Compatibility**
Tested with nodejs 0.12.7
Fixed unit test in master that failed on windows ('/' vs '\' paths)
