### PR TITLE
Fix path.basename when filename is undefined (node 6.0)

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -71,20 +71,24 @@ module.exports = function(file, options, callback) {
 
 	function extractFormData(file, options) {
 
-		var fileContents, fileName;
+		var fileContents;
+        var fileName = options.name;
 		if (typeof file === 'string') {
 			fileContents = fs.createReadStream(file);
-			fileName = path.basename(options.name || file);
+			fileName = fileName || file;
 		} else if (Buffer.isBuffer(file) || isReadableStream(file)) {
 			fileContents = file;
-			fileName = path.basename(options.name);
 		}
+
+        if (!fileName) {
+            throw new Error('Filename is missing from options');
+        }
 
 		return {
 			file: {
 				value: fileContents,
 				options: {
-					filename: fileName,
+					filename: path.basename(fileName),
 					contentType: 'application/octet-stream'
 				}
 			}

--- a/test.js
+++ b/test.js
@@ -32,7 +32,7 @@ describe('push', function() {
 
   describe('build url', function () {
     it('should include `replace` parameter if it is provided', function () {
-      octo.push(new Buffer('hello world'), { replace: true, host: 'http://myweb/' });
+      octo.push(new Buffer('hello world'), { replace: true, host: 'http://myweb/', name: 'package.tar' });
       var req = postStub.lastCall.args[0];
       expect(req.url).to.equal('http://myweb/api/packages/raw?replace=true');
     });
@@ -51,7 +51,7 @@ describe('push', function() {
     });
 
     function testUrl(host, expected) {
-      octo.push(new Buffer('hello world'), { host: host });
+      octo.push(new Buffer('hello world'), { host: host, name: 'package.tar' });
       var req = postStub.lastCall.args[0];
       expect(req.url).to.equal(expected);
     }
@@ -63,7 +63,8 @@ describe('push', function() {
     octo.push(new Buffer('hello world'), {
       apikey: 'KEY',
       replace: true,
-      host: 'http://localhost'
+      host: 'http://localhost',
+      name: 'package.tar',
     }, function(err, result) {
       expect(err).to.be.null;
       expect(result).to.eql(body);


### PR DESCRIPTION
Node 6.0 can't do the following path.basename(undefined) so it has to be string. Fixed tests and made sure filename is mandatory.

```
TypeError: Path must be a string. Received undefined
      at assertPath (path.js:7:11)
      at Object.basename (path.js:1357:5)
      at extractFormData (lib/push.js:80:20)
      at performPost (lib/push.js:33:14)
      at Object.module.exports [as push] (lib/push.js:23:3)
      at testUrl (test.js:54:12)
      at Context.<anonymous> (test.js:50:7)
```
