### PR TITLE
Add ability to append sub-directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ If the `filePath` parameter is missing, the provided path to the file on disk wi
 If the `filePath` is a glob pattern, then the glob is used to append files to the package and the other arguments will be ignored.
 Supplying a folder path without being a glob will be ignored.
 
+#### package.appendSubDir(dir, toRoot)
+Adds the sub-directory `dir` to the archive. Adds the contents of `dir` to the root of the archive if `toRoot` is true (defaults to false).
+
 #### package.toStream(function callback(err, data){})
 Completes the packaging of the files and invokes the provided callback, returning an object containing the stream instance and name.
 
@@ -73,6 +76,7 @@ octo.pack()
   .append('buffer files/hello.txt', new Buffer('hello world'), {date: new Date(2011, 11, 11)})
   .append('stream.txt', fs.createReadStream('./package.json'))
   .append('lib/myfile.js')
+  .appendSubDir('dist/', true)
   .toFile('./bin', function (err, data) {
     console.log("Package Saved: "+ data.name);
   });

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -45,6 +45,16 @@ module.exports = function(type, options) {
     return methods;
   };
 
+  methods.appendSubDir = function appendSubDir(dir, toRoot) {
+    if (typeof toRoot == 'undefined')
+    {
+      toRoot = false;
+    }
+    dir = dir.replace(/\\/g, '/');
+    archive.directory(dir, !toRoot);
+    return methods;
+  };
+
   methods.toFile = function toFile(dir, cb) {
     if(typeof dir === 'function') {
       cb = dir;

--- a/test.js
+++ b/test.js
@@ -158,4 +158,37 @@ describe('pack', function() {
           done();
         });
   });
+
+  it('can add subdirectories', function (done) {
+    octo.pack({id: 'test-subdir'})
+        .appendSubDir('lib/')
+        .toFile('./bin/', function (err, data) {
+            expect(err).to.be.null;
+            expect(data.size).to.be.above(0);
+            expect(data.name).not.to.be.null;
+            expect(data.path.indexOf('bin')).to.equal(0);
+
+            fs.exists(data.path, function (exists) {
+                expect(exists).to.be.true;
+                done();
+            });
+        });
+  });
+
+  it('can add subdirectory content to root of archive', function (done) {
+    octo.pack({id: 'test-subdir-root'})
+        .appendSubDir('lib/', true)
+        .toFile('./bin/', function (err, data) {
+            expect(err).to.be.null;
+            expect(data.size).to.be.above(0);
+            expect(data.name).not.to.be.null;
+            expect(data.path.indexOf('bin')).to.equal(0);
+
+            fs.exists(data.path, function (exists) {
+                expect(exists).to.be.true;
+                done();
+            });
+        });
+  });
+
 });


### PR DESCRIPTION
Exposes additional functionality from the archiver package so that
users can add a specific sub-directory, and have the option of putting
the content in the root of the archive.