### PR TITLE
Add the ability to set a timeout for push

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,14 @@ Required property that points to the Octopus Server instance the package should 
 Flag to force overwrite of existing package if one already exists with the same ID and version.
 
 #### options.apiKey
-Key linked to account with `BuiltInFeedPush` permissions. 
+Key linked to account with `BuiltInFeedPush` permissions.
 If `options.replace` is set to true and a package with the same ID and version already exists then the `BuiltInFeedAdminister` permission is required.
 
 #### options.name
 If a Stream or Buffer object is provided in the `file` parameter, the package name needs is required to properly store and use in Octopus Deploy. If this value is not provided and a path has been provided in the `file` parameter then the name of the file itself will be used.
+
+#### options.timeout
+Optional property to set the timeout in milliseconds used for requests to the Octopus Server instance.  If not specified, the default is 60000.
 
 #### callback
 Invoked when the HTTP request has completed. The `data` object contains the HTTP response body that was returned as a result of a successful push.

--- a/lib/push.js
+++ b/lib/push.js
@@ -31,11 +31,12 @@ module.exports = function(file, options, callback) {
 				'X-Octopus-ApiKey': options.apikey || options.apiKey
 			},
 			formData: extractFormData(fileBytes, options),
-			json: true
+			json: true,
+			timeout: options.timeout || 60000,
 		};
 
 		if (verbose) {
-			console.info('Pushing to: ' + requestOptions.url);
+			console.info('Pushing to: ' + requestOptions.url + ' with timeout ' + requestOptions.timeout + 'ms');
 		}
 
 		request.post(requestOptions, function (err, resp, body) {

--- a/test.js
+++ b/test.js
@@ -58,7 +58,7 @@ describe('push', function() {
 
     function testUrl(host, expected) {
       octo.push(Buffer.from('hello world'), { host: host, name: 'package.tar' });
-      var req = postStub.lastCall.args[0];
+      var req = postStub.firstCall.args[0];
       expect(req.url).to.equal(expected);
     }
   });
@@ -79,6 +79,21 @@ describe('push', function() {
 
     var callback = postStub.firstCall.args[1];
     callback(null, {statusCode: 200}, body);
+  });
+
+  describe('timeout', function () {
+    it('should include `timeout` parameter default if it is not provided', function () {
+      octo.push(Buffer.from('hello world'), { host: 'http://myweb/', name: 'package.tar' });
+      var req = postStub.lastCall.args[0];
+      expect(req.timeout).to.be.not.undefined;
+      expect(req.timeout).to.equal(60000);
+    });
+    it('should include `timeout` parameter if it provided', function () {
+      octo.push(Buffer.from('hello world'), { host: 'http://myweb/', name: 'package.tar', timeout: 120000 });
+      var req = postStub.lastCall.args[0];
+      expect(req.timeout).to.not.undefined;
+      expect(req.timeout).to.equal(120000);
+    });
   });
 });
 


### PR DESCRIPTION
Hi, 

Our package builder jobs ran into a timeout issue pushing a large package >2gb which was failing due to a POST request timeout.

```js
var octo = require('@octopusdeploy/octopackjs');

octo.push('./bin/Sample.Web.3.2.1.tar.gz', {
        host: 'http://octopus-server/', 
        apikey: 'API-XXXXXXXXX',
        replace: true
    }, function(err, result) {
     if(!err) {
        console.log("Package Pushed:" + body.Title + " v"+ body.Version +" (" + fileSizeString(body.PackageSizeBytes) +"nytes)"); 
     }
});
```

Error received:
```
Pushing to: 'https://octopus-server/api/packages/raw' with timeout 120000ms
--
Push response: 408
error pushing to octo!
{
"statusCode": 408,
"statusMessage": "REQUEST_TIMEOUT",
"response": {
   "statusCode": 408,
   "headers": {
   "content-length": "0",
   "connection": "Close",
   ...
}
}
```

New Feature allows:
```js
var octo = require('@octopusdeploy/octopackjs');

octo.push('./bin/Sample.Web.3.2.1.tar.gz', {
        host: 'http://octopus-server/', 
        apikey: 'API-XXXXXXXXX',
        replace: true,
        timeout: 120000,
    }, function(err, result) {
     if(!err) {
        console.log("Package Pushed:" + body.Title + " v"+ body.Version +" (" + fileSizeString(body.PackageSizeBytes) +"nytes)"); 
     }
});
```


I am submitting this PR to add a timeout option into the push function.

Let me know if its ok to merge or if you need any changes.

Kind regards, 
Fergus
